### PR TITLE
Fix le lancement des process dans quick:test

### DIFF
--- a/app/Console/Commands/Test.php
+++ b/app/Console/Commands/Test.php
@@ -163,7 +163,7 @@ class Test extends Command
             foreach ($this->dirs as $dir) {
                 $command = "find ".$dir." -iname '*.php' -exec php -l '{}' \; | grep '^No syntax errors' -v";
 
-                $process = new Process($command);
+                $process = Process::fromShellCommandline($command);
 
                 $process->run(function ($type, $line) use (&$failed) {
                     if ($line !== '') {
@@ -182,7 +182,7 @@ class Test extends Command
             $bar = $this->output->createProgressBar(count($files));
 
             foreach ($files as $file) {
-                $process = new Process("php -l ".$file);
+                $process = Process::fromShellCommandline("php -l ".$file);
                 $lines = [];
 
                 $process->run(function ($type, $line) use (&$lines) {
@@ -330,7 +330,7 @@ class Test extends Command
      */
     private function process(string $command)
     {
-        $process = new Process($command);
+        $process = Process::fromShellCommandline($command);
 
         $process->run(function ($type, $line) {
             $this->output->write($line);


### PR DESCRIPTION
Fix l'initialisation des commandes bash qui font de la stream redirection, en utilisant la commande statique fromShellCommandline au lieu du constructeur Process.
Voir https://symfony.com/doc/current/components/process.html#using-features-from-the-os-shell