### PR TITLE
Correction d'une faille de contamination des routes publiques

### DIFF
--- a/app/Http/Middleware/CheckAuth.php
+++ b/app/Http/Middleware/CheckAuth.php
@@ -33,7 +33,7 @@ class CheckAuth
         if ($request->user() !== null) {
             $token = $request->user()->token();
 
-            if (!$token->transient()) {
+            if ($token && !$token->transient()) {
                 $client = Client::find($token->client_id);
 
                 // On vérifie uniquement pour les tokens qui ne sont pas un token personnel ou lié à une application sans session.

--- a/app/Models/Asso.php
+++ b/app/Models/Asso.php
@@ -108,7 +108,7 @@ class Asso extends Model implements CanBeOwner, CanHaveContacts, CanHaveCalendar
      * TODO: Transformer en scope.
      *
      * @param  string $login
-     * @return Asso
+     * @return mixed
      */
     public static function findByLogin(string $login)
     {

--- a/app/Services/Scopes.php
+++ b/app/Services/Scopes.php
@@ -74,7 +74,10 @@ class Scopes
      */
     protected function getAuthMiddleware()
     {
-        return $this->allowPublic ? 'auth.public' : 'auth';
+        $middleware = $this->allowPublic ? 'auth.public' : 'auth';
+        $this->allowPublic = false;
+
+        return $middleware;
     }
 
     /**

--- a/app/Traits/Controller/v1/HasAssos.php
+++ b/app/Traits/Controller/v1/HasAssos.php
@@ -94,9 +94,9 @@ trait HasAssos
     protected function getAsso(Request $request, string $asso_id, User $user=null, Semester $semester=null): Asso
     {
         if (\Uuid::validate($asso_id)) {
-            $asso = Asso::with('parent')->makeHidden('parent_id')->find($asso_id);
+            $asso = Asso::with('parent')->find($asso_id);
         } else {
-            $asso = Asso::with('parent')->makeHidden('parent_id')->findByLogin($asso_id);
+            $asso = Asso::with('parent')->findByLogin($asso_id);
         }
 
         if ($asso) {
@@ -111,7 +111,7 @@ trait HasAssos
                 }
             }
 
-            return $asso;
+            return $asso->makeHidden('parent_id');
         } else {
             abort(404, "Assocation non trouvée");
         }


### PR DESCRIPTION
Quand on définissait une route comme public, il y avait un effet de contamination qui faisait que même les routes "privée" devenaient publiques. (on pouvait gérer les assos en public...)