### PR TITLE
Retourne les rôles du semestre courant par défaut

### DIFF
--- a/app/Http/Controllers/v1/User/RoleController.php
+++ b/app/Http/Controllers/v1/User/RoleController.php
@@ -12,6 +12,7 @@
 namespace App\Http\Controllers\v1\User;
 
 use App\Http\Controllers\v1\Controller;
+use App\Models\Semester;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use App\Http\Requests\UserRoleRequest;

--- a/app/Http/Controllers/v1/User/RoleController.php
+++ b/app/Http/Controllers/v1/User/RoleController.php
@@ -71,7 +71,12 @@ class RoleController extends Controller
     public function index(Request $request, string $user_id=null): JsonResponse
     {
         $user = $this->getUser($request, $user_id, true);
-        $semester_id = $this->getSemester($request->input('semester_id'))->id;
+        if ($request->has('semester')) {
+            $semester_id = Semester::getSemester($request->input('semester'))->id;
+        } else {
+            $semester_id = Semester::getThisSemester()->id;
+        }
+
         $roles = $user->getUserRoles(null, $semester_id);
 
         return response()->json($roles->map(function ($role) {


### PR DESCRIPTION
Lorsque que l'on souhaite récupérer les rôles d'un utilisateur/de l'utilisateur courant, si le paramètre `semester` n'est pas passé, on considère qu'il s'agit du semestre courant.