### PR TITLE
Fix filter on active/inactive users

### DIFF
--- a/app/Http/Controllers/v1/User/UserController.php
+++ b/app/Http/Controllers/v1/User/UserController.php
@@ -76,7 +76,7 @@ class UserController extends Controller
         if (count($choices) === 2) {
             $users = new User;
         } else {
-            $users = User::where('active', \Scopes::hasOne($request, 'client-get-users-active'));
+            $users = User::where('is_active', \Scopes::hasOne($request, 'client-get-users-active'));
         }
 
         $users = $users->getSelection()->map(function ($user) {


### PR DESCRIPTION
Fix l'erreur sur la route `api/va/users`, typo sur l'attribut User `active` -> `is_active`.
Fix #226 