### PR TITLE
User has to be validated to be shown in API results

### DIFF
--- a/app/Http/Controllers/v1/Asso/MemberController.php
+++ b/app/Http/Controllers/v1/Asso/MemberController.php
@@ -128,6 +128,7 @@ class MemberController extends Controller
         $members = $asso->allMembers()
             ->where('semester_id', $semester->id)
             ->whereNotNull('role_id')
+            ->whereNotNull('validated_by_id')
             ->getSelection(true)
             ->map(function ($member) {
                 $member->pivot = [


### PR DESCRIPTION
This fix is only for when using the route /assos/{asso_id}/members, another fix for the route /user/assos will be necessary (for hiding unvalidated associations from career for example) but will need more time and is not as urgent as this one.