### PR TITLE
--enable-gd-native-ttf removed since php 7.2.0 fix docker compilation

### DIFF
--- a/docker/configurations/back/Dockerfile
+++ b/docker/configurations/back/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && \
     && docker-php-ext-configure intl \
     && docker-php-ext-configure zip --with-libzip \
     && docker-php-ext-configure gd \
-            --enable-gd-native-ttf \
             --with-freetype-dir=/usr/include/freetype2 \
             --with-png-dir=/usr/include \
             --with-jpeg-dir=/usr/include \


### PR DESCRIPTION
without this 'fix':
```
configure: error: unrecognized options: --enable-gd-native-ttf
```
note: this is not a fix, I haven't properly verified if the back used this dependency, but I guess not